### PR TITLE
Encryption services

### DIFF
--- a/backend/src/main/java/com/team20/pki/certificates/service/PrivateKeyEncryptionService.java
+++ b/backend/src/main/java/com/team20/pki/certificates/service/PrivateKeyEncryptionService.java
@@ -1,0 +1,35 @@
+package com.team20.pki.certificates.service;
+
+import com.team20.pki.encryption.exception.EncryptionError;
+import com.team20.pki.encryption.service.EncryptionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PrivateKeyEncryptionService {
+    private final EncryptionService encryptionService;
+
+    public byte[] encryptKey(PrivateKey plain, String organization) {
+        return encryptionService.encrypt(plain.getEncoded(), organization);
+    }
+
+    public PrivateKey decryptKey(byte[] encrypted, String organization) {
+        byte[] decrypted = encryptionService.decrypt(encrypted, organization);
+        try {
+            return KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(decrypted));
+        } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+            // Should never happen
+            log.error(e.getMessage());
+            throw new EncryptionError();
+        }
+    }
+}

--- a/backend/src/main/java/com/team20/pki/encryption/exception/EncryptionError.java
+++ b/backend/src/main/java/com/team20/pki/encryption/exception/EncryptionError.java
@@ -1,0 +1,10 @@
+package com.team20.pki.encryption.exception;
+
+public class EncryptionError extends RuntimeException {
+    public EncryptionError() {
+    }
+
+    public EncryptionError(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/team20/pki/encryption/mapper/OrganizationKeyMapper.java
+++ b/backend/src/main/java/com/team20/pki/encryption/mapper/OrganizationKeyMapper.java
@@ -1,0 +1,14 @@
+package com.team20.pki.encryption.mapper;
+
+import com.team20.pki.encryption.model.OrganizationKey;
+import com.team20.pki.encryption.model.WrappedKey;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface OrganizationKeyMapper {
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "organizationName", source = "organization")
+    @Mapping(target = "wrappedKey", source = "wrappedKey")
+    OrganizationKey toOrganizationKey(String organization, WrappedKey wrappedKey);
+}

--- a/backend/src/main/java/com/team20/pki/encryption/model/OrganizationKey.java
+++ b/backend/src/main/java/com/team20/pki/encryption/model/OrganizationKey.java
@@ -1,0 +1,33 @@
+package com.team20.pki.encryption.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(
+        name = "organization_keys",
+        indexes = {@Index(columnList = "organization_name")}
+)
+public class OrganizationKey {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false)
+    private UUID id;
+
+    @NotNull
+    @Column(nullable = false)
+    private String organizationName;
+
+    @Embedded
+    private WrappedKey wrappedKey;
+}

--- a/backend/src/main/java/com/team20/pki/encryption/model/WrappedKey.java
+++ b/backend/src/main/java/com/team20/pki/encryption/model/WrappedKey.java
@@ -1,0 +1,22 @@
+package com.team20.pki.encryption.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Lob;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class WrappedKey {
+    @Lob
+    @Column(name = "wrapped_key", nullable = false)
+    byte[] cipherText;
+
+    @Lob
+    @Column(name = "wrapped_key_iv", nullable = false)
+    byte[] iv;
+}

--- a/backend/src/main/java/com/team20/pki/encryption/repository/OrganizationKeyRepository.java
+++ b/backend/src/main/java/com/team20/pki/encryption/repository/OrganizationKeyRepository.java
@@ -1,0 +1,11 @@
+package com.team20.pki.encryption.repository;
+
+import com.team20.pki.encryption.model.OrganizationKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OrganizationKeyRepository extends JpaRepository<OrganizationKey, UUID> {
+    Optional<OrganizationKey> findByOrganizationName(String organizationName);
+}

--- a/backend/src/main/java/com/team20/pki/encryption/service/CryptoHashService.java
+++ b/backend/src/main/java/com/team20/pki/encryption/service/CryptoHashService.java
@@ -1,39 +1,5 @@
 package com.team20.pki.encryption.service;
 
-import com.team20.pki.config.properties.AuthConfigProperties;
-import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.codec.binary.Hex;
-import org.springframework.stereotype.Service;
-
-import javax.crypto.Mac;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
-import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
-
-@Service
-@RequiredArgsConstructor
-public class CryptoHashService {
-    private final AuthConfigProperties authConfig;
-    private SecretKey hmacKey;
-
-    @PostConstruct
-    public void init() {
-        byte[] keyBytes = Base64.getDecoder().decode(authConfig.getHmacSecretKey());
-        hmacKey = new SecretKeySpec(keyBytes, "HmacSHA256");
-    }
-
-    public String hash(String value) {
-        try {
-            Mac mac = Mac.getInstance("HmacSHA256");
-            mac.init(hmacKey);
-            byte[] hashBytes = mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
-            return Hex.encodeHexString(hashBytes);
-        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
-            throw new IllegalArgumentException("Invalid key");
-        }
-    }
+public interface CryptoHashService {
+    String hash(String value);
 }

--- a/backend/src/main/java/com/team20/pki/encryption/service/EncryptionService.java
+++ b/backend/src/main/java/com/team20/pki/encryption/service/EncryptionService.java
@@ -1,0 +1,6 @@
+package com.team20.pki.encryption.service;
+
+public interface EncryptionService {
+    byte[] encrypt(byte[] value, String organization);
+    byte[] decrypt(byte[] cipherText, String organization);
+}

--- a/backend/src/main/java/com/team20/pki/encryption/service/MasterKeyProvider.java
+++ b/backend/src/main/java/com/team20/pki/encryption/service/MasterKeyProvider.java
@@ -1,0 +1,11 @@
+package com.team20.pki.encryption.service;
+
+import javax.crypto.SecretKey;
+
+/**
+ * Loads the master key used to encrypt (wrap) organization keys.
+ * Implementations can read from env, KMS, HSM, etc.
+ */
+public interface MasterKeyProvider {
+    SecretKey loadMasterKey();
+}

--- a/backend/src/main/java/com/team20/pki/encryption/service/OrganizationKeyProvider.java
+++ b/backend/src/main/java/com/team20/pki/encryption/service/OrganizationKeyProvider.java
@@ -1,0 +1,15 @@
+package com.team20.pki.encryption.service;
+
+import javax.crypto.SecretKey;
+
+/**
+ * Returns or creates organization-specific key.
+ * It <b>must</b> return an AES key for symmetric encryption, but can use/store any other keys under the hood.
+ * It is <b>highly</b> advised to use {@link MasterKeyProvider} for internal key encryption.
+ */
+public interface OrganizationKeyProvider {
+    /**
+     * Returns organization key (existing or newly created).
+     */
+    SecretKey getOrCreateOrganizationKey(String organization);
+}

--- a/backend/src/main/java/com/team20/pki/encryption/service/impl/DbOrganizationKeyProvider.java
+++ b/backend/src/main/java/com/team20/pki/encryption/service/impl/DbOrganizationKeyProvider.java
@@ -1,0 +1,102 @@
+package com.team20.pki.encryption.service.impl;
+
+import com.team20.pki.encryption.exception.EncryptionError;
+import com.team20.pki.encryption.mapper.OrganizationKeyMapper;
+import com.team20.pki.encryption.model.OrganizationKey;
+import com.team20.pki.encryption.model.WrappedKey;
+import com.team20.pki.encryption.repository.OrganizationKeyRepository;
+import com.team20.pki.encryption.service.MasterKeyProvider;
+import com.team20.pki.encryption.service.OrganizationKeyProvider;
+import com.team20.pki.util.SecureRandomGenerator;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+
+/**
+ * Stores an organization's symmetric DEK in the database wrapped by the master key.
+ * Uses {@link MasterKeyProvider} to load the master key.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DbOrganizationKeyProvider implements OrganizationKeyProvider {
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH = 128;
+
+    private final MasterKeyProvider masterKeyProvider;
+    private final OrganizationKeyRepository organizationKeyRepository;
+    private final OrganizationKeyMapper organizationKeyMapper;
+
+    private SecretKey masterKey;
+
+    @PostConstruct
+    public void init() {
+        masterKey = masterKeyProvider.loadMasterKey();
+    }
+
+    public WrappedKey wrapKey(SecretKey rawKey, SecretKey wrapperKey) {
+        try {
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            byte[] iv = SecureRandomGenerator.generateBytes(GCM_IV_LENGTH);
+            cipher.init(Cipher.WRAP_MODE, wrapperKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+            byte[] wrapped = cipher.wrap(rawKey);
+            return new WrappedKey(wrapped, iv);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException e) {
+            // In case of wrong parameters, should never happen
+            log.error(e.getMessage());
+            throw new EncryptionError();
+        } catch (IllegalBlockSizeException | InvalidKeyException e) {
+            log.error(e.getMessage());
+            throw new EncryptionError("Invalid key");
+        }
+    }
+
+    public SecretKey unwrapKey(WrappedKey wrappedKey, SecretKey wrapperKey) {
+        try {
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.UNWRAP_MODE, wrapperKey, new GCMParameterSpec(GCM_TAG_LENGTH, wrappedKey.getIv()));
+            return (SecretKey) cipher.unwrap(wrappedKey.getCipherText(), "AES", Cipher.SECRET_KEY);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException |
+                 InvalidAlgorithmParameterException e) {
+            // In case of wrong parameters, should never happen
+            log.error(e.getMessage());
+            throw new EncryptionError();
+        } catch (InvalidKeyException e) {
+            log.error(e.getMessage());
+            throw new EncryptionError("Invalid key");
+        }
+    }
+
+    private void saveOrganizationKey(String organization, SecretKey key) {
+        WrappedKey wrappedKey = wrapKey(key, masterKey);
+        OrganizationKey orgKey = organizationKeyMapper.toOrganizationKey(organization, wrappedKey);
+        organizationKeyRepository.save(orgKey);
+    }
+
+    @Override
+    public SecretKey getOrCreateOrganizationKey(String organization) {
+        Optional<OrganizationKey> orgKey = organizationKeyRepository.findByOrganizationName(organization);
+        if (orgKey.isPresent()) {
+            WrappedKey key = orgKey.get().getWrappedKey();
+            return unwrapKey(key, masterKey);
+        } else {
+            byte[] keyBytes = SecureRandomGenerator.generateBytes(32);
+            SecretKey key = new SecretKeySpec(keyBytes, "AES");
+            saveOrganizationKey(organization, key);
+            return key;
+        }
+    }
+}

--- a/backend/src/main/java/com/team20/pki/encryption/service/impl/DefaultEncryptionService.java
+++ b/backend/src/main/java/com/team20/pki/encryption/service/impl/DefaultEncryptionService.java
@@ -1,0 +1,70 @@
+package com.team20.pki.encryption.service.impl;
+
+import com.team20.pki.encryption.exception.EncryptionError;
+import com.team20.pki.encryption.service.EncryptionService;
+import com.team20.pki.encryption.service.OrganizationKeyProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.*;
+import javax.crypto.spec.GCMParameterSpec;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DefaultEncryptionService implements EncryptionService {
+    private static final int GCM_TAG_LENGTH = 128; // bits
+    private static final int GCM_IV_LENGTH = 12;   // bytes
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+
+    private final OrganizationKeyProvider organizationKeyProvider;
+
+    @Override
+    public byte[] encrypt(byte[] value, String organization) {
+        SecretKey orgKey = organizationKeyProvider.getOrCreateOrganizationKey(organization);
+
+        try {
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, orgKey);
+
+            byte[] iv = cipher.getIV();
+            byte[] cipherText = cipher.doFinal(value);
+
+            byte[] encrypted = new byte[iv.length + cipherText.length];
+            System.arraycopy(iv, 0, encrypted, 0, iv.length);
+            System.arraycopy(cipherText, 0, encrypted, iv.length, cipherText.length);
+
+            return encrypted;
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
+                 IllegalBlockSizeException | BadPaddingException e) {
+            log.error("Encryption failed", e);
+            throw new EncryptionError();
+        }
+    }
+
+    @Override
+    public byte[] decrypt(byte[] encrypted, String organization) {
+        SecretKey orgKey = organizationKeyProvider.getOrCreateOrganizationKey(organization);
+
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            byte[] cipherText = new byte[encrypted.length - GCM_IV_LENGTH];
+            System.arraycopy(encrypted, 0, iv, 0, iv.length);
+            System.arraycopy(encrypted, iv.length, cipherText, 0, cipherText.length);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            GCMParameterSpec gcmSpec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+            cipher.init(Cipher.DECRYPT_MODE, orgKey, gcmSpec);
+
+            return cipher.doFinal(cipherText);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
+                 IllegalBlockSizeException | BadPaddingException | InvalidAlgorithmParameterException e) {
+            log.error("Decryption failed", e);
+            throw new EncryptionError();
+        }
+    }
+}

--- a/backend/src/main/java/com/team20/pki/encryption/service/impl/EnvMasterKeyProvider.java
+++ b/backend/src/main/java/com/team20/pki/encryption/service/impl/EnvMasterKeyProvider.java
@@ -1,0 +1,24 @@
+package com.team20.pki.encryption.service.impl;
+
+import com.team20.pki.encryption.service.MasterKeyProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.codec.Hex;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+@Service
+public class EnvMasterKeyProvider implements MasterKeyProvider {
+    private final String masterKeyHex;
+
+    public EnvMasterKeyProvider(@Value("${secret.master-key}") String masterKeyHex) {
+        this.masterKeyHex = masterKeyHex;
+    }
+
+    @Override
+    public SecretKey loadMasterKey() {
+        byte[] keyBytes = Hex.decode(masterKeyHex);
+        return new SecretKeySpec(keyBytes, "AES");
+    }
+}

--- a/backend/src/main/java/com/team20/pki/encryption/service/impl/HmacCryptoHashService.java
+++ b/backend/src/main/java/com/team20/pki/encryption/service/impl/HmacCryptoHashService.java
@@ -1,0 +1,40 @@
+package com.team20.pki.encryption.service.impl;
+
+import com.team20.pki.config.properties.AuthConfigProperties;
+import com.team20.pki.encryption.service.CryptoHashService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.binary.Hex;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+public class HmacCryptoHashService implements CryptoHashService {
+    private final AuthConfigProperties authConfig;
+    private SecretKey hmacKey;
+
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = Base64.getDecoder().decode(authConfig.getHmacSecretKey());
+        hmacKey = new SecretKeySpec(keyBytes, "HmacSHA256");
+    }
+
+    public String hash(String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(hmacKey);
+            byte[] hashBytes = mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
+            return Hex.encodeHexString(hashBytes);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new IllegalArgumentException("Invalid key");
+        }
+    }
+}

--- a/backend/src/main/java/com/team20/pki/util/SecureRandomGenerator.java
+++ b/backend/src/main/java/com/team20/pki/util/SecureRandomGenerator.java
@@ -12,4 +12,10 @@ public class SecureRandomGenerator {
         secureRandom.nextBytes(randomBytes);
         return base64UrlEncoder.encodeToString(randomBytes);
     }
+
+    public static byte[] generateBytes(int length) {
+        byte[] randomBytes = new byte[length];
+        secureRandom.nextBytes(randomBytes);
+        return randomBytes;
+    }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,6 +9,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.username=postgres
 spring.datasource.password=postgres
 spring.jpa.hibernate.ddl-auto=update
+spring.datasource.hikari.auto-commit=false
 
 frontend-url=http://localhost:5173
 
@@ -37,6 +38,8 @@ auth.refresh-token-expiration-time-ms=86400000
 auth.activation-code-expiration-minutes=1440
 
 config.refresh-token.delete-cron=0 0 4 * * *
+
+secret.master-key=${PKI_MASTER_KEY}
 
 logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR


### PR DESCRIPTION
Added centralized encryption utilities.

Per-organization symmetric keys are used for all encryption. Organization keys are wrapped with a single master key.
Currently, master key is loaded from app configuration and per-organization keys are stored encrypted with master (symmetric) in the database. However, the space is left for alternative future implementations (e.g. external KMS or HSM).

Also added RSA private key encryption service as a convenience layer for certificate private key storage.

Further integration with RSA private key storage mechanism is required.