### PR TITLE
[change] Authorization granted authorities

### DIFF
--- a/backend/src/main/java/com/team20/pki/authentication/model/UserDetailsImpl.java
+++ b/backend/src/main/java/com/team20/pki/authentication/model/UserDetailsImpl.java
@@ -10,9 +10,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.UUID;
 
-import static com.team20.pki.common.model.User.Role.ADMINISTRATOR;
-import static com.team20.pki.common.model.User.Role.CA_USER;
-
 public class UserDetailsImpl implements UserDetails {
     @Getter
     private final UUID userId;
@@ -51,13 +48,11 @@ public class UserDetailsImpl implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
-        if(userRole == CA_USER || userRole == ADMINISTRATOR) {
-            authorities.add(new SimpleGrantedAuthority("ROLE_CA"));
-        }
-        if(userRole == ADMINISTRATOR) {
-            authorities.add(new SimpleGrantedAuthority("ROLE_ADMINISTRATOR"));
-        }
+        authorities.add(new SimpleGrantedAuthority(switch (userRole) {
+            case REGULAR_USER -> "ROLE_USER";
+            case CA_USER -> "ROLE_CA";
+            case ADMINISTRATOR -> "ROLE_ADMINISTRATOR";
+        }));
         return authorities;
     }
 


### PR DESCRIPTION
Changed the rules of assigning granted authorities based on user role.

Old set up granted higher-privilege user roles with all lower-privilege granted authorities.

New set up grants only one authority per user role, creating a one-to-one mapping.