### PR TITLE
[hotfix] Double account activation request

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,10 @@
-import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 import { BrowserRouter } from "react-router";
 
 createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </StrictMode>
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
 );


### PR DESCRIPTION
React strict mode renders component twice to detect inconsistencies. This is now turned off to avoid double account activation requests.

On the server side, the issue of concurrent activation requests is resolved using database integrity checks.